### PR TITLE
Change any :texttype properties from 'text/plain' to 'text/html'.

### DIFF
--- a/lib/canvas_cc/canvas_cc/matching_question_writer.rb
+++ b/lib/canvas_cc/canvas_cc/matching_question_writer.rb
@@ -9,13 +9,13 @@ module CanvasCc::CanvasCC
         presentation_node.response_lid(:ident => "response_#{match[:id]}") do |response_node|
           next unless match[:question_text].length > 0
           response_node.material do |material_node|
-            material_node.mattext(match[:question_text], :texttype => 'text/plain')
+            material_node.mattext(match[:question_text], :texttype => 'text/html')
           end
           response_node.render_choice do |choice_node|
             question.matches.each do |possible_match|
               choice_node.response_label(:ident => possible_match[:id]) do |label_node|
                 label_node.material do |material_node|
-                  material_node.mattext(possible_match[:answer_text], :texttype => 'text/plain')
+                  material_node.mattext(possible_match[:answer_text], :texttype => 'text/html')
                 end
               end
             end
@@ -24,7 +24,7 @@ module CanvasCc::CanvasCC
             question.distractors.each do |distractor|
               choice_node.response_label(:ident => Digest::MD5.hexdigest(distractor)) do |label_node|
                 label_node.material do |material_node|
-                  material_node.mattext(distractor, :texttype => 'text/plain')
+                  material_node.mattext(distractor, :texttype => 'text/html')
                 end
               end
             end
@@ -62,7 +62,7 @@ module CanvasCc::CanvasCC
         item_node.itemfeedback(:ident => "#{match[:id]}_fb") do |feedback_node|
           feedback_node.flow_mat do |flow_node|
             flow_node.material do |material_node|
-              material_node.mattext match[:answer_feedback], :texttype => 'text/plain'
+              material_node.mattext match[:answer_feedback], :texttype => 'text/html'
             end
           end
         end

--- a/lib/canvas_cc/canvas_cc/multiple_dropdowns_question_writer.rb
+++ b/lib/canvas_cc/canvas_cc/multiple_dropdowns_question_writer.rb
@@ -8,13 +8,13 @@ module CanvasCc::CanvasCC
       question.responses.each do |response|
         presentation_node.response_lid(:ident => "response_#{response[:id]}") do |response_node|
           response_node.material do |material_node|
-            material_node.mattext(response[:id], :texttype => 'text/plain')
+            material_node.mattext(response[:id], :texttype => 'text/html')
           end
           response_node.render_choice do |choice_node|
             response[:choices].each do |choice|
               choice_node.response_label(:ident => choice[:id]) do |label_node|
                 label_node.material do |material_node|
-                  material_node.mattext(choice[:text], :texttype => 'text/plain')
+                  material_node.mattext(choice[:text], :texttype => 'text/html')
                 end
               end
             end

--- a/lib/canvas_cc/canvas_cc/question_writer.rb
+++ b/lib/canvas_cc/canvas_cc/question_writer.rb
@@ -83,7 +83,7 @@ module CanvasCc::CanvasCC
         item_node.itemfeedback(:ident => 'general_fb') do |fb_node|
           fb_node.flow_mat do |flow_node|
             flow_node.material do |material_node|
-              material_node.mattext(question.general_feedback, :texttype => 'text/plain')
+              material_node.mattext(question.general_feedback, :texttype => 'text/html')
             end
           end
         end
@@ -93,7 +93,7 @@ module CanvasCc::CanvasCC
         item_node.itemfeedback(:ident => 'general_correct_fb') do |fb_node|
           fb_node.flow_mat do |flow_node|
             flow_node.material do |material_node|
-              material_node.mattext(question.general_correct_feedback, :texttype => 'text/plain')
+              material_node.mattext(question.general_correct_feedback, :texttype => 'text/html')
             end
           end
         end
@@ -103,7 +103,7 @@ module CanvasCc::CanvasCC
         item_node.itemfeedback(:ident => 'general_incorrect_fb') do |fb_node|
           fb_node.flow_mat do |flow_node|
             flow_node.material do |material_node|
-              material_node.mattext(question.general_incorrect_feedback, :texttype => 'text/plain')
+              material_node.mattext(question.general_incorrect_feedback, :texttype => 'text/html')
             end
           end
         end
@@ -121,7 +121,7 @@ module CanvasCc::CanvasCC
         item_node.itemfeedback(:ident => "#{answer.id}_fb") do |feedback_node|
           feedback_node.flow_mat do |flow_node|
             flow_node.material do |material_node|
-              material_node.mattext answer.feedback, :texttype => 'text/plain'
+              material_node.mattext answer.feedback, :texttype => 'text/html'
             end
           end
         end


### PR DESCRIPTION
This allows the changed fields to properly render HTML such as embedded images.